### PR TITLE
Fix regressions in sanitizing none variants, new codegen module

### DIFF
--- a/sanitizer-macros/src/arg.rs
+++ b/sanitizer-macros/src/arg.rs
@@ -4,10 +4,12 @@ use syn::{Ident, LitInt};
 pub struct Args {
     pub args: Vec<String>,
 }
+
 impl Args {
     pub fn len(&self) -> usize {
         self.args.len()
     }
+
     pub fn new(args: Vec<String>) -> Self {
         Self { args }
     }
@@ -22,6 +24,7 @@ impl ArgBuilder {
         owned.retain(|character| !character.is_whitespace());
         LitInt::new(&owned, Span::call_site())
     }
+
     pub fn ident(ident: &str) -> Ident {
         let mut owned = ident.to_owned();
         owned.retain(|character| !character.is_whitespace());

--- a/sanitizer-macros/src/codegen/enums.rs
+++ b/sanitizer-macros/src/codegen/enums.rs
@@ -1,0 +1,63 @@
+use crate::codegen::sanitization::Sanitization;
+use crate::codegen::Entity;
+use crate::type_ident::TypeIdent;
+use proc_macro2::TokenStream;
+use quote::quote;
+
+pub struct EnumGen {
+    field_name: Entity,
+    is_int: bool,
+}
+
+impl EnumGen {
+    pub fn new(field_name: Entity, type_ident: &TypeIdent) -> Self {
+        Self {
+            field_name,
+            is_int: type_ident.is_int,
+        }
+    }
+
+    pub fn body(&self, sanitizers: TokenStream) -> TokenStream {
+        let field_name = &self.field_name;
+        let operand = Sanitization::new(self.is_int);
+        let literal = operand.literal();
+        let field = operand.field(&literal);
+        let call = operand.method_calls(field);
+        let call_final = self.call();
+        let body = if self.is_int {
+            let re_assign = operand.method_calls(quote! {
+                *x
+            });
+            quote! {
+                let mut instance = #call;
+                if let Self::#field_name(x) = self {
+                    instance = #re_assign
+                    #sanitizers
+                    #call_final
+                }
+            }
+        } else {
+            let re_assign = operand.method_calls(quote! {
+                x.clone()
+            });
+            quote! {
+                let mut instance = #call
+                if let Self::#field_name(x) = self {
+                    instance = #re_assign
+                    #sanitizers
+                    #call_final
+                }
+            }
+        };
+        quote! {
+            #body
+
+        }
+    }
+
+    fn call(&self) -> TokenStream {
+        quote! {
+            *x = instance.get();
+        }
+    }
+}

--- a/sanitizer-macros/src/codegen/mod.rs
+++ b/sanitizer-macros/src/codegen/mod.rs
@@ -1,0 +1,8 @@
+use proc_macro2::Ident;
+
+pub mod enums;
+pub mod sanitization;
+pub mod sanitizers;
+pub mod structs;
+
+type Entity = Ident;

--- a/sanitizer-macros/src/codegen/sanitization.rs
+++ b/sanitizer-macros/src/codegen/sanitization.rs
@@ -1,0 +1,44 @@
+use proc_macro2::TokenStream;
+use quote::quote;
+
+pub struct Sanitization {
+    is_int: bool,
+}
+
+impl Sanitization {
+    pub fn new(is_int: bool) -> Self {
+        Self { is_int }
+    }
+
+    pub fn literal(&self) -> TokenStream {
+        if self.is_int {
+            quote! { 0 }
+        } else {
+            quote! { String::new() }
+        }
+    }
+
+    pub fn method_calls(&self, field: TokenStream) -> TokenStream {
+        if self.is_int {
+            quote! {
+                IntSanitizer::from(#field);
+            }
+        } else {
+            quote! {
+                StringSanitizer::from(#field);
+            }
+        }
+    }
+
+    pub fn field(&self, field: &TokenStream) -> TokenStream {
+        if self.is_int {
+            quote! {
+                #field
+            }
+        } else {
+            quote! {
+                #field.as_str()
+            }
+        }
+    }
+}

--- a/sanitizer-macros/src/codegen/sanitizers.rs
+++ b/sanitizer-macros/src/codegen/sanitizers.rs
@@ -90,103 +90,6 @@ pub fn meta_list(meta: &NestedMeta) -> Result<PathOrList, SanitizerError> {
     }
 }
 
-pub fn init_struct(
-    init: &mut TokenStream,
-    type_ident: &TypeIdent,
-    field: &Ident,
-    call: &mut TokenStream,
-) {
-    if type_ident.is_option {
-        if type_ident.is_int {
-            if type_ident.is_nested {
-                init.append_all(quote! {
-                    let mut instance = IntSanitizer::from(0);
-                    if let Some(x) = self.#field {
-                        if let Some(y) = x {
-                            instance = IntSanitizer::from(y);
-                        }
-                    }
-                })
-            } else {
-                init.append_all(quote! {
-                    let mut instance = IntSanitizer::from(0);
-                    if let Some(x) = self.#field {
-                        instance = IntSanitizer::from(x);
-                    }
-                })
-            }
-        } else {
-            if type_ident.is_nested {
-                init.append_all(quote! {
-                    let mut instance = StringSanitizer::from(String::new());
-                    if let Some(x) = &self.#field {
-                        if let Some(y) = x {
-                            instance = StringSanitizer::from(y.as_str());
-                        }
-                    }
-                })
-            } else {
-                init.append_all(quote! {
-                    let mut instance = StringSanitizer::from(String::new());
-                    if let Some(x) = &self.#field {
-                        instance = StringSanitizer::from(x.as_str());
-                    }
-                })
-            }
-        }
-        if type_ident.is_nested {
-            call.append_all(quote! {
-                self.#field = Some(Some(instance.get()));
-            });
-        } else {
-            call.append_all(quote! {
-                self.#field = Some(instance.get());
-            });
-        }
-    } else {
-        if type_ident.is_int {
-            init.append_all(quote! {
-                let mut instance = IntSanitizer::from(self.#field);
-            })
-        } else {
-            init.append_all(quote! {
-                let mut instance = StringSanitizer::from(self.#field.as_str());
-            })
-        }
-        call.append_all(quote! {
-            self.#field = instance.get();
-        });
-    }
-}
-
-pub fn init_enum(
-    init: &mut TokenStream,
-    type_ident: &TypeIdent,
-    field_name: &Ident,
-    call: &mut TokenStream,
-) {
-    if type_ident.is_int {
-        init.append_all(quote! {
-            let mut instance = IntSanitizer::from(0);
-            if let Self::#field_name(x) = self {
-                instance = IntSanitizer::from(*x);
-            }
-        })
-    } else {
-        init.append_all(quote! {
-            let mut instance = StringSanitizer::from(String::new());
-            if let Self::#field_name(x) = self {
-                instance = StringSanitizer::from(x.clone());
-            }
-        })
-    }
-    call.append_all(quote! {
-        if let Self::#field_name(x) = self {
-            *x = instance.get();
-        };
-    });
-}
-
 pub fn get_first_arg(meta: &NestedMeta) -> Option<String> {
     match meta {
         NestedMeta::Lit(literal) => match literal {
@@ -208,6 +111,7 @@ impl PathOrList {
             false
         }
     }
+
     pub fn get_args(&self) -> &Args {
         if let Self::List(_, args) = self {
             args

--- a/sanitizer-macros/src/codegen/structs.rs
+++ b/sanitizer-macros/src/codegen/structs.rs
@@ -1,0 +1,127 @@
+use crate::codegen::sanitization::Sanitization;
+use crate::codegen::Entity;
+use crate::type_ident::TypeIdent;
+use proc_macro2::TokenStream;
+use quote::{quote, TokenStreamExt};
+
+pub struct StructGen {
+    field_name: Entity,
+    is_int: bool,
+    is_option: bool,
+    is_option_nested: bool,
+}
+
+impl StructGen {
+    pub fn new(field_name: Entity, type_ident: &TypeIdent) -> Self {
+        Self {
+            field_name,
+            is_int: type_ident.is_int,
+            is_option: type_ident.is_option,
+            is_option_nested: type_ident.is_nested,
+        }
+    }
+
+    fn field_or_value(&self) -> TokenStream {
+        let struct_instance = Sanitization::new(self.is_int);
+        if self.is_option {
+            let literal = struct_instance.literal();
+            quote! {
+                #literal
+            }
+        } else {
+            let ident = &self.field_name;
+            let field = struct_instance.field(&quote! { #ident });
+            quote! {
+                self.#field
+            }
+        }
+    }
+
+    fn operand(&self) -> TokenStream {
+        let field = &self.field_name;
+        if self.is_int {
+            quote! {
+                self.#field
+            }
+        } else {
+            quote! {
+                &self.#field
+            }
+        }
+    }
+
+    fn new_value(&self) -> TokenStream {
+        let field_value = Sanitization::new(self.is_int);
+        if self.is_option_nested {
+            let val = field_value.field(&quote! { y });
+            field_value.method_calls(val)
+        } else {
+            let val = field_value.field(&quote! { x });
+            field_value.method_calls(val)
+        }
+    }
+
+    fn call(&self) -> TokenStream {
+        if self.is_option {
+            if self.is_option_nested {
+                quote! {
+                    Some(Some(instance.get()));
+                }
+            } else {
+                quote! {
+                    Some(instance.get());
+                }
+            }
+        } else {
+            quote! {
+                instance.get();
+            }
+        }
+    }
+
+    pub fn body(&self, sanitizers: TokenStream) -> TokenStream {
+        let init = self.init();
+        let operand = self.operand();
+        let call = self.call();
+        let mut rest = quote! {};
+        let field = &self.field_name;
+        if self.is_option {
+            let new_value = self.new_value();
+            if self.is_option_nested {
+                rest.append_all(quote! {
+                    if let Some(x) = #operand {
+                        if let Some(y) = x {
+                            instance = #new_value
+                            #sanitizers
+                            self.#field = #call
+                        };
+                    };
+                })
+            } else {
+                rest.append_all(quote! {
+                    if let Some(x) = #operand {
+                        instance = #new_value
+                        #sanitizers
+                        self.#field = #call
+                    };
+                })
+            };
+            quote! {
+                let mut instance = #init
+                #rest
+            }
+        } else {
+            quote! {
+                let mut instance = #init
+                #sanitizers
+                self.#field = #call
+            }
+        }
+    }
+
+    fn init(&self) -> TokenStream {
+        let init = Sanitization::new(self.is_int);
+        let value = self.field_or_value();
+        init.method_calls(value)
+    }
+}

--- a/sanitizer-macros/src/lib.rs
+++ b/sanitizer-macros/src/lib.rs
@@ -2,7 +2,9 @@
 #![forbid(unsafe_code)]
 //! Macros that allows seamless sanitizing
 //! on struct fields
-use crate::codegen::{init_enum, init_struct, methods_layout};
+use crate::codegen::enums::EnumGen;
+use crate::codegen::sanitizers::methods_layout;
+use crate::codegen::structs::StructGen;
 use crate::sanitizer::parse_sanitizers;
 use crate::type_ident::TypeOrNested;
 use proc_macro::TokenStream;
@@ -74,6 +76,7 @@ mod type_ident;
 /// - **custom(function)**: A custom function that is called to sanitize a field
 /// according to any other way.
 #[proc_macro_derive(Sanitize, attributes(sanitize))]
+#[allow(unused_assignments)]
 pub fn sanitize(input: TokenStream) -> TokenStream {
     let input_parsed = parse_macro_input!(input as DeriveInput);
     let name = input_parsed.ident;
@@ -82,41 +85,39 @@ pub fn sanitize(input: TokenStream) -> TokenStream {
     if let Ok(ref val) = parsed {
         inner_body.append_all(val.get_map().iter().map(|r| {
             let field = r.0;
-            let mut call = quote! {};
-            let mut init = quote! {};
-            let mut layout = quote! {};
+            let mut body = quote! {};
             match field {
                 TypeOrNested::Type(field, type_ident) => {
-                    layout = methods_layout(r.1, type_ident.clone());
-
+                    let sanitizer_calls = methods_layout(r.1, type_ident.clone());
+                    let mut stream = Default::default();
                     if val.is_enum() {
-                        init_enum(&mut init, type_ident, field, &mut call);
+                        stream = EnumGen::new(field.clone(), type_ident).body(sanitizer_calls);
                     } else {
-                        init_struct(&mut init, type_ident, field, &mut call);
+                        stream = StructGen::new(field.clone(), type_ident).body(sanitizer_calls);
                     }
+                    body.append_all(stream)
                 }
                 TypeOrNested::Nested(field, type_ident) => {
+                    let call = quote! { <#type_ident as Sanitize>::sanitize };
                     if val.is_enum() {
-                        call.append_all({
+                        body.append_all({
                             quote! {
                                 if let Self::#field(x) = self {
-                                    <#type_ident as Sanitize>::sanitize(x);
+                                    #call(x);
                                 }
                             }
                         });
                     } else {
-                        call.append_all({
+                        body.append_all({
                             quote! {
-                                <#type_ident as Sanitize>::sanitize(&mut self.#field);
+                                #call(&mut self.#field);
                             }
                         });
                     }
                 }
             }
             quote! {
-                #init
-                #layout
-                #call
+                #body
             }
         }));
     } else {

--- a/sanitizer-macros/src/sanitizer.rs
+++ b/sanitizer-macros/src/sanitizer.rs
@@ -165,6 +165,7 @@ impl StructOrEnum {
             false
         }
     }
+
     pub fn get_map(&self) -> &FieldMap {
         match self {
             Self::Enum(enum_fields) => enum_fields,

--- a/sanitizer-macros/src/sanitizers/int.rs
+++ b/sanitizer-macros/src/sanitizers/int.rs
@@ -1,5 +1,5 @@
 use crate::arg::ArgBuilder;
-use crate::codegen::PathOrList;
+use crate::codegen::sanitizers::PathOrList;
 use crate::sanitizer::SanitizerError;
 use proc_macro2::TokenStream;
 use quote::quote;

--- a/sanitizer-macros/src/sanitizers/string.rs
+++ b/sanitizer-macros/src/sanitizers/string.rs
@@ -1,5 +1,5 @@
 use crate::arg::ArgBuilder;
-use crate::codegen::PathOrList;
+use crate::codegen::sanitizers::PathOrList;
 use crate::sanitizer::SanitizerError;
 use proc_macro2::TokenStream;
 use quote::quote;

--- a/sanitizer-macros/src/type_ident.rs
+++ b/sanitizer-macros/src/type_ident.rs
@@ -73,6 +73,7 @@ fn is_option(typepath: TypePath, is_nested: bool) -> Result<OptionWrapper, Sanit
             };
         }
     }
+
     Ok(OptionWrapper::new(
         false,
         Ident::new("_", Span::call_site()),
@@ -84,7 +85,6 @@ fn is_option(typepath: TypePath, is_nested: bool) -> Result<OptionWrapper, Sanit
 pub struct TypeIdent {
     pub ident: Ident,
     pub is_int: bool,
-
     pub is_option: bool,
     pub is_nested: bool,
 }
@@ -98,12 +98,15 @@ impl TypeIdent {
             is_nested,
         }
     }
+
     pub fn is_string(&self) -> bool {
         self.ident == "String"
     }
+
     pub fn is_int(&self) -> bool {
         self.is_int
     }
+
     pub fn is_string_or_int(&self) -> bool {
         self.is_int || self.ident == "String"
     }
@@ -121,6 +124,7 @@ impl Default for TypeIdent {
 
 impl TryFrom<Type> for TypeIdent {
     type Error = SanitizerError;
+
     fn try_from(type_ident: Type) -> Result<Self, Self::Error> {
         match type_ident {
             Type::Path(type_path) => {

--- a/sanitizer-macros/tests/option.rs
+++ b/sanitizer-macros/tests/option.rs
@@ -14,6 +14,11 @@ struct First {
     // double option nested
     #[sanitize(trim)]
     name_last: Option<Option<String>>,
+    #[sanitize(trim)]
+    // None values should NOT be sanitized
+    city: Option<String>,
+    // Same with nested options
+    country: Option<Option<String>>,
 }
 
 #[test]
@@ -23,10 +28,14 @@ fn option_test() {
         address: Some(String::from("Mars, i'm elon musk   ")),
         age: Some(0),
         name_last: Some(Some(String::from(" William   "))),
+        city: None,
+        country: None,
     };
     instance.sanitize();
     assert_eq!(instance.name, Some(String::from("Test")));
     assert_eq!(instance.address, Some(String::from("Mars, i'm elon musk")));
     assert_eq!(instance.age, Some(1));
     assert_eq!(instance.name_last, Some(Some(String::from("William"))));
+    assert_eq!(instance.city, None);
+    assert_eq!(instance.country, None);
 }


### PR DESCRIPTION
Create new codegen module which generates code differently and fixes some regressions in sanitizing none variants, codegen is more modular now. 
